### PR TITLE
Restrict verbose logging to debug builds

### DIFF
--- a/NeoCardium/Helpers/ExceptionHelper.cs
+++ b/NeoCardium/Helpers/ExceptionHelper.cs
@@ -113,9 +113,9 @@ namespace NeoCardium.Helpers
         /// </summary>
         public static async Task LogErrorAsync(string message, Exception? ex = null, [CallerMemberName] string caller = "")
         {
-            // TODO: In Release-Builds könntest du Logging deaktivieren, je nach Anforderung(Einstellung).
-            //if (!Debugger.IsAttached)
-            //    return;
+#if !DEBUG
+            return;
+#endif
 
             try
             {
@@ -143,9 +143,9 @@ namespace NeoCardium.Helpers
         /// </summary>
         public static void LogError(string message, Exception? ex = null, [CallerMemberName] string caller = "")
         {
-            // TODO: In Release-Builds könntest du Logging deaktivieren, je nach Anforderung(Einstellung).
-            //if (!Debugger.IsAttached)
-            //    return;
+#if !DEBUG
+            return;
+#endif
 
             try
             {


### PR DESCRIPTION
## Summary
- log only in debug builds by guarding logging methods with `#if !DEBUG`

## Testing
- `dotnet build NeoCardium.sln -c Debug` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684f450ea368832ea3aba4b2f3746c33