### PR TITLE
Add settings page options

### DIFF
--- a/NeoCardium/ViewModels/SettingsPageViewModel.cs
+++ b/NeoCardium/ViewModels/SettingsPageViewModel.cs
@@ -1,0 +1,77 @@
+using System;
+using CommunityToolkit.Mvvm.ComponentModel;
+using Microsoft.UI.Xaml;
+using Windows.Storage;
+
+namespace NeoCardium.ViewModels
+{
+    public class SettingsPageViewModel : ObservableObject
+    {
+        private readonly ApplicationDataContainer localSettings = ApplicationData.Current.LocalSettings;
+
+        private const string ThemeKey = "AppTheme";
+        private const string StatsKey = "ShowStatistics";
+        private const string LicenseKey = "LicenseStatus";
+
+        private string _selectedTheme = "Default";
+        public string SelectedTheme
+        {
+            get => _selectedTheme;
+            set
+            {
+                if (SetProperty(ref _selectedTheme, value))
+                {
+                    localSettings.Values[ThemeKey] = value;
+                    if (Enum.TryParse<ElementTheme>(value, out var theme) && App._mainWindow?.Content is FrameworkElement root)
+                    {
+                        root.RequestedTheme = theme;
+                    }
+                }
+            }
+        }
+
+        private bool _showStatistics;
+        public bool ShowStatistics
+        {
+            get => _showStatistics;
+            set
+            {
+                if (SetProperty(ref _showStatistics, value))
+                {
+                    localSettings.Values[StatsKey] = value;
+                }
+            }
+        }
+
+        private string _licenseStatus = "Free";
+        public string LicenseStatus
+        {
+            get => _licenseStatus;
+            set
+            {
+                if (SetProperty(ref _licenseStatus, value))
+                {
+                    localSettings.Values[LicenseKey] = value;
+                }
+            }
+        }
+
+        public SettingsPageViewModel()
+        {
+            if (localSettings.Values.TryGetValue(ThemeKey, out var themeObj) && themeObj is string storedTheme)
+            {
+                _selectedTheme = storedTheme;
+            }
+
+            if (localSettings.Values.TryGetValue(StatsKey, out var statsObj) && statsObj is bool storedStats)
+            {
+                _showStatistics = storedStats;
+            }
+
+            if (localSettings.Values.TryGetValue(LicenseKey, out var licObj) && licObj is string storedLicense)
+            {
+                _licenseStatus = storedLicense;
+            }
+        }
+    }
+}

--- a/NeoCardium/Views/SettingsPage.xaml
+++ b/NeoCardium/Views/SettingsPage.xaml
@@ -1,21 +1,38 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Page
+    x:Class="NeoCardium.Views.SettingsPage"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     mc:Ignorable="d"
-    
-    xmlns:local="using:NeoCardium.Views"
-    
-    x:Class="NeoCardium.Views.SettingsPage"
+    xmlns:vm="using:NeoCardium.ViewModels"
+    x:DataType="vm:SettingsPageViewModel"
     Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
 
-    <Grid>
-        <TextBlock Text="Einstellungen: Hier kannst du dein Design anpassen!" 
-                   HorizontalAlignment="Center"
-                   VerticalAlignment="Center"
-                   FontSize="24"
-                   FontWeight="Bold"/>
-    </Grid>
+    <StackPanel Padding="20" Spacing="20">
+        <TextBlock Text="Einstellungen" FontSize="24" FontWeight="Bold"/>
+
+        <!-- Theme selection -->
+        <StackPanel>
+            <TextBlock Text="Theme" FontWeight="SemiBold" Margin="0,10,0,5"/>
+            <ComboBox SelectedValue="{x:Bind ViewModel.SelectedTheme, Mode=TwoWay}" SelectedValuePath="Tag" Width="200">
+                <ComboBoxItem Content="System" Tag="Default"/>
+                <ComboBoxItem Content="Hell" Tag="Light"/>
+                <ComboBoxItem Content="Dunkel" Tag="Dark"/>
+            </ComboBox>
+        </StackPanel>
+
+        <!-- General preferences -->
+        <StackPanel>
+            <TextBlock Text="Allgemein" FontWeight="SemiBold" Margin="0,10,0,5"/>
+            <CheckBox Content="Statistik anzeigen" IsChecked="{x:Bind ViewModel.ShowStatistics, Mode=TwoWay}"/>
+        </StackPanel>
+
+        <!-- Premium / Account section -->
+        <StackPanel>
+            <TextBlock Text="Konto" FontWeight="SemiBold" Margin="0,10,0,5"/>
+            <TextBlock Text="{x:Bind ViewModel.LicenseStatus}"/>
+        </StackPanel>
+    </StackPanel>
 </Page>

--- a/NeoCardium/Views/SettingsPage.xaml.cs
+++ b/NeoCardium/Views/SettingsPage.xaml.cs
@@ -1,17 +1,7 @@
 using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Linq;
-using System.Runtime.InteropServices.WindowsRuntime;
-using Windows.Foundation;
-using Windows.Foundation.Collections;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
-using Microsoft.UI.Xaml.Controls.Primitives;
-using Microsoft.UI.Xaml.Data;
-using Microsoft.UI.Xaml.Input;
-using Microsoft.UI.Xaml.Media;
-using Microsoft.UI.Xaml.Navigation;
+using NeoCardium.ViewModels;
 
 // To learn more about WinUI, the WinUI project structure,
 // and more about our project templates, see: http://aka.ms/winui-project-info.
@@ -23,9 +13,17 @@ namespace NeoCardium.Views
     /// </summary>
     public sealed partial class SettingsPage : Page
     {
+        public SettingsPageViewModel ViewModel { get; } = new SettingsPageViewModel();
+
         public SettingsPage()
         {
             this.InitializeComponent();
+            DataContext = ViewModel;
+
+            if (Enum.TryParse<ElementTheme>(ViewModel.SelectedTheme, out var theme) && App._mainWindow?.Content is FrameworkElement root)
+            {
+                root.RequestedTheme = theme;
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary
- flesh out SettingsPage with theme and account settings UI
- introduce `SettingsPageViewModel` with local settings persistence
- connect page to view model

## Testing
- `dotnet build NeoCardium.sln -c Release` *(fails: `dotnet: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_684f452adda8832e8c75b7f3184c61db