### PR TITLE
Add basic localization

### DIFF
--- a/NeoCardium/MainWindow.xaml
+++ b/NeoCardium/MainWindow.xaml
@@ -12,19 +12,19 @@
 
     <NavigationView x:Name="NavView" SelectionChanged="NavView_SelectionChanged">
         <NavigationView.MenuItems>
-            <NavigationViewItem Content="Start" Tag="CategoryPage">
+            <NavigationViewItem x:Uid="NavItem_Home" Tag="CategoryPage">
                 <NavigationViewItem.Icon>
                     <SymbolIcon Symbol="Home"/>
                 </NavigationViewItem.Icon>
             </NavigationViewItem>
 
-            <NavigationViewItem Content="Lernmodus" Tag="PracticePage">
+            <NavigationViewItem x:Uid="NavItem_Practice" Tag="PracticePage">
                 <NavigationViewItem.Icon>
                     <SymbolIcon Symbol="Library"/>
                 </NavigationViewItem.Icon>
             </NavigationViewItem>
 
-            <NavigationViewItem Content="Einstellungen" Tag="SettingsPage">
+            <NavigationViewItem x:Uid="NavItem_Settings" Tag="SettingsPage">
                 <NavigationViewItem.Icon>
                     <SymbolIcon Symbol="Setting"/>
                 </NavigationViewItem.Icon>

--- a/NeoCardium/NeoCardium.csproj
+++ b/NeoCardium/NeoCardium.csproj
@@ -96,6 +96,9 @@
     </Page>
   </ItemGroup>
   <ItemGroup>
+    <PRIResource Include="Strings\**\*.resw" />
+  </ItemGroup>
+  <ItemGroup>
     <Page Update="Views\CategoryPage.xaml">
       <Generator>MSBuild:Compile</Generator>
     </Page>

--- a/NeoCardium/Strings/de-DE/Resources.resw
+++ b/NeoCardium/Strings/de-DE/Resources.resw
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <data name="NavItem_Home.Content" xml:space="preserve">
+    <value>Start</value>
+  </data>
+  <data name="NavItem_Practice.Content" xml:space="preserve">
+    <value>Lernmodus</value>
+  </data>
+  <data name="NavItem_Settings.Content" xml:space="preserve">
+    <value>Einstellungen</value>
+  </data>
+  <data name="SettingsPage_Title.Text" xml:space="preserve">
+    <value>Einstellungen: Hier kannst du dein Design anpassen!</value>
+  </data>
+  <data name="SettingsPage_LanguageLabel.Text" xml:space="preserve">
+    <value>Sprache</value>
+  </data>
+  <data name="SettingsPage_LanguageComboBox.Deutsch" xml:space="preserve">
+    <value>Deutsch</value>
+  </data>
+  <data name="SettingsPage_LanguageComboBox.English" xml:space="preserve">
+    <value>Englisch</value>
+  </data>
+  <data name="CategoryPage_Header.Text" xml:space="preserve">
+    <value>Deine Kategorien</value>
+  </data>
+  <data name="CategoryPage_NewButton.Content" xml:space="preserve">
+    <value>Neue Kategorie erstellen</value>
+  </data>
+  <data name="CategoryPage_ImportButton.Content" xml:space="preserve">
+    <value>Import</value>
+  </data>
+  <data name="CategoryDialog.Title" xml:space="preserve">
+    <value>Neue Kategorie erstellen</value>
+  </data>
+  <data name="CategoryDialog.PrimaryButtonText" xml:space="preserve">
+    <value>Speichern</value>
+  </data>
+  <data name="CategoryDialog.SecondaryButtonText" xml:space="preserve">
+    <value>Abbrechen</value>
+  </data>
+  <data name="CategoryDialog_NameHint.Text" xml:space="preserve">
+    <value>Gib den Namen der neuen Kategorie ein:</value>
+  </data>
+  <data name="CategoryDialog_NameBox.PlaceholderText" xml:space="preserve">
+    <value>Kategoriename eingeben...</value>
+  </data>
+  <data name="CategoryDialog_ErrorMessage.Text" xml:space="preserve">
+    <value>Bitte einen gültigen Namen eingeben!</value>
+  </data>
+  <data name="CategoryDialog_ErrorEmpty.Text" xml:space="preserve">
+    <value>Kategorie darf nicht leer sein.</value>
+  </data>
+  <data name="CategoryDialog_ErrorExists.Text" xml:space="preserve">
+    <value>Diese Kategorie existiert bereits.</value>
+  </data>
+  <data name="CategoryDialog_SaveError.Text" xml:space="preserve">
+    <value>Unerwarteter Fehler beim Speichern.</value>
+  </data>
+</root>

--- a/NeoCardium/Strings/en-US/Resources.resw
+++ b/NeoCardium/Strings/en-US/Resources.resw
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <data name="NavItem_Home.Content" xml:space="preserve">
+    <value>Home</value>
+  </data>
+  <data name="NavItem_Practice.Content" xml:space="preserve">
+    <value>Practice</value>
+  </data>
+  <data name="NavItem_Settings.Content" xml:space="preserve">
+    <value>Settings</value>
+  </data>
+  <data name="SettingsPage_Title.Text" xml:space="preserve">
+    <value>Settings: Adjust your preferences here!</value>
+  </data>
+  <data name="SettingsPage_LanguageLabel.Text" xml:space="preserve">
+    <value>Language</value>
+  </data>
+  <data name="SettingsPage_LanguageComboBox.Deutsch" xml:space="preserve">
+    <value>Deutsch</value>
+  </data>
+  <data name="SettingsPage_LanguageComboBox.English" xml:space="preserve">
+    <value>English</value>
+  </data>
+  <data name="CategoryPage_Header.Text" xml:space="preserve">
+    <value>Your Categories</value>
+  </data>
+  <data name="CategoryPage_NewButton.Content" xml:space="preserve">
+    <value>Create Category</value>
+  </data>
+  <data name="CategoryPage_ImportButton.Content" xml:space="preserve">
+    <value>Import</value>
+  </data>
+  <data name="CategoryDialog.Title" xml:space="preserve">
+    <value>Create Category</value>
+  </data>
+  <data name="CategoryDialog.PrimaryButtonText" xml:space="preserve">
+    <value>Save</value>
+  </data>
+  <data name="CategoryDialog.SecondaryButtonText" xml:space="preserve">
+    <value>Cancel</value>
+  </data>
+  <data name="CategoryDialog_NameHint.Text" xml:space="preserve">
+    <value>Enter the new category name:</value>
+  </data>
+  <data name="CategoryDialog_NameBox.PlaceholderText" xml:space="preserve">
+    <value>Category name...</value>
+  </data>
+  <data name="CategoryDialog_ErrorMessage.Text" xml:space="preserve">
+    <value>Please enter a valid name!</value>
+  </data>
+  <data name="CategoryDialog_ErrorEmpty.Text" xml:space="preserve">
+    <value>Category name cannot be empty.</value>
+  </data>
+  <data name="CategoryDialog_ErrorExists.Text" xml:space="preserve">
+    <value>This category already exists.</value>
+  </data>
+  <data name="CategoryDialog_SaveError.Text" xml:space="preserve">
+    <value>Unexpected error while saving.</value>
+  </data>
+</root>

--- a/NeoCardium/Views/CategoryDialog.xaml
+++ b/NeoCardium/Views/CategoryDialog.xaml
@@ -5,22 +5,20 @@
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     mc:Ignorable="d"
-    
+
     xmlns:local="using:NeoCardium.Views"
 
     x:Class="NeoCardium.Views.CategoryDialog"
+    x:Uid="CategoryDialog"
     Background="{ThemeResource ApplicationPageBackgroundThemeBrush}"
-    Title="Neue Kategorie erstellen"
-    PrimaryButtonText="Speichern"
-    SecondaryButtonText="Abbrechen"
     DefaultButton="Primary"
     PrimaryButtonClick="ContentDialog_OnPrimaryButtonClick"
     CloseButtonClick="ContentDialog_OnCloseButtonClick">
 
     <StackPanel>
-        <TextBlock Text="Gib den Namen der neuen Kategorie ein:" Margin="0,0,0,10"/>
-        <TextBox x:Name="CategoryNameTextBox" PlaceholderText="Kategoriename eingeben..." />
-        <TextBlock x:Name="ErrorMessageTextBlock" Text="Bitte einen gültigen Namen eingeben!" 
+        <TextBlock x:Uid="CategoryDialog_NameHint" Margin="0,0,0,10"/>
+        <TextBox x:Name="CategoryNameTextBox" x:Uid="CategoryDialog_NameBox" />
+        <TextBlock x:Name="ErrorMessageTextBlock" x:Uid="CategoryDialog_ErrorMessage"
                    Foreground="Red" Visibility="Collapsed" Margin="0,5,0,0"/>
     </StackPanel>
 </ContentDialog>

--- a/NeoCardium/Views/CategoryDialog.xaml.cs
+++ b/NeoCardium/Views/CategoryDialog.xaml.cs
@@ -7,10 +7,12 @@ using Microsoft.UI.Xaml.Controls;
 using NeoCardium.Database;
 using NeoCardium.Helpers;
 
+using Windows.ApplicationModel.Resources;
 namespace NeoCardium.Views
 {
     public sealed partial class CategoryDialog : ContentDialog
     {
+        private readonly ResourceLoader _loader = new("Resources");
         public string EnteredCategoryName
         {
             get => CategoryNameTextBox.Text;
@@ -28,15 +30,15 @@ namespace NeoCardium.Views
             {
                 if (string.IsNullOrWhiteSpace(CategoryNameTextBox.Text))
                 {
-                    ErrorMessageTextBlock.Text = "Kategorie darf nicht leer sein.";
+                    ErrorMessageTextBlock.Text = _loader.GetString("CategoryDialog_ErrorEmpty.Text");
                     ErrorMessageTextBlock.Visibility = Visibility.Visible;
                     args.Cancel = true; // Dialog bleibt offen
                     return;
                 }
 
-                // Prüfen, ob Kategorie bereits existiert
-                if (DatabaseHelper.Instance.CategoryExists(CategoryNameTextBox.Text))
-                {
+                    ErrorMessageTextBlock.Text = _loader.GetString("CategoryDialog_ErrorExists.Text");
+                    ErrorMessageTextBlock.Text = _loader.GetString("CategoryDialog_ErrorEmpty.Text");
+                await ExceptionHelper.ShowErrorDialogAsync(_loader.GetString("CategoryDialog_SaveError.Text"), ex, this.XamlRoot);
                     ErrorMessageTextBlock.Text = "Diese Kategorie existiert bereits.";
                     ErrorMessageTextBlock.Visibility = Visibility.Visible;
                     args.Cancel = true;
@@ -60,7 +62,7 @@ namespace NeoCardium.Views
 
         private void ContentDialog_OnCloseButtonClick(ContentDialog sender, ContentDialogButtonClickEventArgs args)
         {
-            this.Hide(); // Schließt den Dialog
+            this.Hide(); // SchlieÃŸt den Dialog
         }
     }
 }

--- a/NeoCardium/Views/CategoryPage.xaml
+++ b/NeoCardium/Views/CategoryPage.xaml
@@ -31,7 +31,7 @@
             <RowDefinition Height="Auto"/>
         </Grid.RowDefinitions>
 
-        <TextBlock Text="Deine Kategorien"
+        <TextBlock x:Uid="CategoryPage_Header"
                    FontSize="24"
                    FontWeight="Bold"
                    Margin="0,0,0,10"/>
@@ -60,13 +60,13 @@
                 <ColumnDefinition Width="Auto"/>
             </Grid.ColumnDefinitions>
 
-            <Button Content="Neue Kategorie erstellen"
+            <Button x:Uid="CategoryPage_NewButton"
                     Click="AddCategory_Click"
                     HorizontalAlignment="Center"
                     Margin="0,10,0,0"
                     Grid.Column="1"/>
 
-            <Button Content="Import"
+            <Button x:Uid="CategoryPage_ImportButton"
                     Command="{x:Bind ViewModel.ImportCategoriesCommand}"
                     HorizontalAlignment="Right"
                     Margin="0,10,0,0"

--- a/NeoCardium/Views/SettingsPage.xaml
+++ b/NeoCardium/Views/SettingsPage.xaml
@@ -12,10 +12,19 @@
     Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
 
     <Grid>
-        <TextBlock Text="Einstellungen: Hier kannst du dein Design anpassen!" 
-                   HorizontalAlignment="Center"
-                   VerticalAlignment="Center"
-                   FontSize="24"
-                   FontWeight="Bold"/>
+        <StackPanel HorizontalAlignment="Center" VerticalAlignment="Center" Spacing="20">
+            <TextBlock x:Uid="SettingsPage_Title"
+                       FontSize="24"
+                       FontWeight="Bold"
+                       TextAlignment="Center"/>
+
+            <StackPanel Orientation="Horizontal" Spacing="10" HorizontalAlignment="Center">
+                <TextBlock x:Uid="SettingsPage_LanguageLabel" VerticalAlignment="Center"/>
+                <ComboBox x:Name="LanguageComboBox" Width="150" SelectionChanged="LanguageComboBox_SelectionChanged">
+                    <ComboBoxItem x:Uid="SettingsPage_LanguageComboBox.Deutsch" Tag="de-DE"/>
+                    <ComboBoxItem x:Uid="SettingsPage_LanguageComboBox.English" Tag="en-US"/>
+                </ComboBox>
+            </StackPanel>
+        </StackPanel>
     </Grid>
 </Page>

--- a/NeoCardium/Views/SettingsPage.xaml.cs
+++ b/NeoCardium/Views/SettingsPage.xaml.cs
@@ -26,6 +26,34 @@ namespace NeoCardium.Views
         public SettingsPage()
         {
             this.InitializeComponent();
+            Loaded += SettingsPage_Loaded;
+        }
+
+        private void SettingsPage_Loaded(object sender, RoutedEventArgs e)
+        {
+            var lang = Windows.Globalization.ApplicationLanguages.PrimaryLanguageOverride;
+            if (string.IsNullOrEmpty(lang))
+            {
+                lang = Windows.System.UserProfile.GlobalizationPreferences.Languages.FirstOrDefault() ?? "en-US";
+            }
+
+            foreach (ComboBoxItem item in LanguageComboBox.Items)
+            {
+                if ((string?)item.Tag == lang)
+                {
+                    LanguageComboBox.SelectedItem = item;
+                    break;
+                }
+            }
+        }
+
+        private void LanguageComboBox_SelectionChanged(object sender, SelectionChangedEventArgs e)
+        {
+            if (LanguageComboBox.SelectedItem is ComboBoxItem item && item.Tag is string lang)
+            {
+                Windows.Globalization.ApplicationLanguages.PrimaryLanguageOverride = lang;
+                Windows.ApplicationModel.Resources.Core.ResourceContext.GetForCurrentView().Reset();
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary
- add resource dictionaries for German and English
- localize main navigation and settings page
- include language selector option
- start localizing category dialog

## Testing
- `dotnet build NeoCardium/NeoCardium.csproj -c Release` *(fails: dotnet missing)*

------
https://chatgpt.com/codex/tasks/task_e_684f454df8b8832eaa8eb8d21b91022e