### PR TITLE
Add pastel theme support

### DIFF
--- a/NeoCardium/App.xaml
+++ b/NeoCardium/App.xaml
@@ -24,6 +24,16 @@
             <converters:EnumToVisibilityConverter x:Key="BooleanToAnswerTextConverter"/>
             <converters:BooleanInverterConverter x:Key="BooleanInverterConverter"/>
             <converters:MultiBooleanToVisibilityConverter x:Key="MultiBooleanToVisibilityConverter"/>
+
+            <!-- Default color resources -->
+            <SolidColorBrush x:Key="CardBackgroundBrush" Color="#1E1E1E"/>
+            <SolidColorBrush x:Key="OptionBackgroundBrush" Color="#292929"/>
+            <SolidColorBrush x:Key="AccentBrush" Color="LightBlue"/>
+            <SolidColorBrush x:Key="StatsBorderBrush" Color="#606060"/>
+            <SolidColorBrush x:Key="DangerBrush" Color="HotPink"/>
+            <SolidColorBrush x:Key="CorrectBrush" Color="LightGreen"/>
+            <SolidColorBrush x:Key="IncorrectBrush" Color="OrangeRed"/>
+            <SolidColorBrush x:Key="SecondaryBrush" Color="Gray"/>
         </ResourceDictionary>
     </Application.Resources>
 </Application>

--- a/NeoCardium/App.xaml.cs
+++ b/NeoCardium/App.xaml.cs
@@ -10,6 +10,33 @@ namespace NeoCardium
     public partial class App : Application
     {
         public static MainWindow? _mainWindow { get; private set; }
+        private static readonly ResourceDictionary _pastelDictionary = new()
+        {
+            Source = new Uri("ms-appx:///Themes/Pastel.xaml")
+        };
+
+        public static void ApplyTheme(string theme)
+        {
+            if (_mainWindow?.Content is FrameworkElement root)
+            {
+                if (theme == "Pastel")
+                {
+                    root.RequestedTheme = ElementTheme.Light;
+                    if (!Current.Resources.MergedDictionaries.Contains(_pastelDictionary))
+                    {
+                        Current.Resources.MergedDictionaries.Add(_pastelDictionary);
+                    }
+                }
+                else
+                {
+                    if (Enum.TryParse<ElementTheme>(theme, out var etheme))
+                    {
+                        root.RequestedTheme = etheme;
+                    }
+                    Current.Resources.MergedDictionaries.Remove(_pastelDictionary);
+                }
+            }
+        }
 
         public App()
         {

--- a/NeoCardium/NeoCardium.csproj
+++ b/NeoCardium/NeoCardium.csproj
@@ -96,6 +96,11 @@
     </Page>
   </ItemGroup>
   <ItemGroup>
+    <Page Include="Themes\Pastel.xaml">
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
+  </ItemGroup>
+  <ItemGroup>
     <PRIResource Include="Strings\**\*.resw" />
   </ItemGroup>
   <ItemGroup>

--- a/NeoCardium/Themes/Pastel.xaml
+++ b/NeoCardium/Themes/Pastel.xaml
@@ -1,0 +1,11 @@
+<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+    <SolidColorBrush x:Key="CardBackgroundBrush" Color="#FFF6E6E6"/>
+    <SolidColorBrush x:Key="OptionBackgroundBrush" Color="#FFFFF6F6"/>
+    <SolidColorBrush x:Key="AccentBrush" Color="#FFA0C4FF"/>
+    <SolidColorBrush x:Key="StatsBorderBrush" Color="#FFDFBFD8"/>
+    <SolidColorBrush x:Key="DangerBrush" Color="#FFFFC1E3"/>
+    <SolidColorBrush x:Key="CorrectBrush" Color="#FF9AE6B4"/>
+    <SolidColorBrush x:Key="IncorrectBrush" Color="#FFF4A6A6"/>
+    <SolidColorBrush x:Key="SecondaryBrush" Color="#FF9E9E9E"/>
+</ResourceDictionary>

--- a/NeoCardium/ViewModels/SettingsPageViewModel.cs
+++ b/NeoCardium/ViewModels/SettingsPageViewModel.cs
@@ -22,10 +22,7 @@ namespace NeoCardium.ViewModels
                 if (SetProperty(ref _selectedTheme, value))
                 {
                     localSettings.Values[ThemeKey] = value;
-                    if (Enum.TryParse<ElementTheme>(value, out var theme) && App._mainWindow?.Content is FrameworkElement root)
-                    {
-                        root.RequestedTheme = theme;
-                    }
+                    App.ApplyTheme(value);
                 }
             }
         }
@@ -72,6 +69,8 @@ namespace NeoCardium.ViewModels
             {
                 _licenseStatus = storedLicense;
             }
+
+            App.ApplyTheme(_selectedTheme);
         }
     }
 }

--- a/NeoCardium/Views/CategoryDialog.xaml
+++ b/NeoCardium/Views/CategoryDialog.xaml
@@ -19,6 +19,6 @@
         <TextBlock x:Uid="CategoryDialog_NameHint" Margin="0,0,0,10"/>
         <TextBox x:Name="CategoryNameTextBox" x:Uid="CategoryDialog_NameBox" />
         <TextBlock x:Name="ErrorMessageTextBlock" x:Uid="CategoryDialog_ErrorMessage"
-                   Foreground="Red" Visibility="Collapsed" Margin="0,5,0,0"/>
+                   Foreground="{StaticResource IncorrectBrush}" Visibility="Collapsed" Margin="0,5,0,0"/>
     </StackPanel>
 </ContentDialog>

--- a/NeoCardium/Views/FlashcardDialog.xaml
+++ b/NeoCardium/Views/FlashcardDialog.xaml
@@ -43,7 +43,7 @@
                 <DataTemplate x:DataType="models:FlashcardAnswer">
                     <StackPanel Orientation="Horizontal">
                         <TextBlock Text="✔"
-                       Foreground="Green"
+                       Foreground="{StaticResource CorrectBrush}"
                        Margin="0,0,5,0"
                        Visibility="{x:Bind IsCorrect, Mode=OneWay, Converter={StaticResource BooleanToVisibilityConverter}}"/>
                         <TextBlock Text="{x:Bind AnswerText, Mode=OneWay}" FontSize="16"/>

--- a/NeoCardium/Views/FlashcardsPage.xaml
+++ b/NeoCardium/Views/FlashcardsPage.xaml
@@ -73,11 +73,11 @@
                 <DataTemplate x:DataType="models:Flashcard">
                     <StackPanel Orientation="Horizontal" Padding="10">
                         <TextBlock>
-                    <Run Text="{x:Bind CorrectCount}" Foreground="Green"/>
-                    <Run Text="✅ " Foreground="Gray"/>
+                    <Run Text="{x:Bind CorrectCount}" Foreground="{StaticResource CorrectBrush}"/>
+                    <Run Text="✅ " Foreground="{StaticResource SecondaryBrush}"/>
 
-                    <Run Text="{x:Bind IncorrectCount}" Foreground="Red"/>
-                    <Run Text="❌ | " Foreground="Gray"/>
+                    <Run Text="{x:Bind IncorrectCount}" Foreground="{StaticResource IncorrectBrush}"/>
+                    <Run Text="❌ | " Foreground="{StaticResource SecondaryBrush}"/>
 
                     <Run Text="{x:Bind Question}" FontWeight="Bold"/>
                         </TextBlock>

--- a/NeoCardium/Views/PracticePage.xaml
+++ b/NeoCardium/Views/PracticePage.xaml
@@ -58,7 +58,7 @@
             </Grid.RowDefinitions>
 
             <!-- Frage-Anzeige -->
-            <Border Padding="20" Background="#1E1E1E" CornerRadius="10" Margin="0,0,0,40" Width="600">
+            <Border Padding="20" Background="{StaticResource CardBackgroundBrush}" CornerRadius="10" Margin="0,0,0,40" Width="600">
                 <TextBlock Text="{Binding CurrentQuestion.Question}"
                            FontSize="24" FontWeight="Bold" Foreground="White" TextWrapping="Wrap"
                            HorizontalAlignment="Center" VerticalAlignment="Center"/>
@@ -89,9 +89,9 @@
                                             Padding="20,10"
                                             Margin="10, 15, 0, 0"
                                             FontSize="18"
-                                            Background="#292929"
+                                            Background="{StaticResource OptionBackgroundBrush}"
                                             Foreground="White"
-                                            BorderBrush="LightBlue"
+                                            BorderBrush="{StaticResource AccentBrush}"
                                             BorderThickness="2"
                                             CornerRadius="15"
                                             HorizontalAlignment="Stretch"
@@ -115,7 +115,7 @@
                         Margin="20"
                         IsEnabled="{Binding IsNotProcessing}"/>
                 <!-- Antwort-Anzeige -->
-                <Border Background="#1E1E1E" CornerRadius="10" Padding="20" Margin="20,10,20,0"
+                <Border Background="{StaticResource CardBackgroundBrush}" CornerRadius="10" Padding="20" Margin="20,10,20,0"
                         Visibility="{Binding IsAnswerRevealed, Converter={StaticResource BooleanToVisibilityConverter}}">
                     <TextBlock Text="{Binding CurrentQuestion.Answer}"
                                FontSize="22" FontWeight="Bold" Foreground="White" 
@@ -142,24 +142,24 @@
                 Visibility="{Binding IsFinalStatisticsVisible, Converter={StaticResource BooleanToVisibilityConverter}}"
                 HorizontalAlignment="Center"
                 VerticalAlignment="Center"
-                BorderThickness="1" BorderBrush="#606060">
+                BorderThickness="1" BorderBrush="{StaticResource StatsBorderBrush}">
             <StackPanel HorizontalAlignment="Center" Spacing="15">
                 <TextBlock Text="📝 Deine Lernstatistik" 
                            FontSize="20" FontWeight="Bold" Foreground="White" 
                            HorizontalAlignment="Center"/>
                 <StackPanel Orientation="Horizontal" HorizontalAlignment="Center">
-                    <TextBlock Text="✅ Richtige Antworten:" Foreground="LightGreen" FontSize="18"/>
-                    <TextBlock Text="{Binding TotalCorrect}" Foreground="LightGreen" FontSize="18" FontWeight="Bold" Margin="5,0,0,0"/>
+                    <TextBlock Text="✅ Richtige Antworten:" Foreground="{StaticResource CorrectBrush}" FontSize="18"/>
+                    <TextBlock Text="{Binding TotalCorrect}" Foreground="{StaticResource CorrectBrush}" FontSize="18" FontWeight="Bold" Margin="5,0,0,0"/>
                 </StackPanel>
                 <StackPanel Orientation="Horizontal" HorizontalAlignment="Center">
-                    <TextBlock Text="❌ Falsche Antworten:" Foreground="OrangeRed" FontSize="18"/>
-                    <TextBlock Text="{Binding TotalIncorrect}" Foreground="OrangeRed" FontSize="18" FontWeight="Bold" Margin="5,0,0,0"/>
+                    <TextBlock Text="❌ Falsche Antworten:" Foreground="{StaticResource IncorrectBrush}" FontSize="18"/>
+                    <TextBlock Text="{Binding TotalIncorrect}" Foreground="{StaticResource IncorrectBrush}" FontSize="18" FontWeight="Bold" Margin="5,0,0,0"/>
                 </StackPanel>
                 <ProgressBar Minimum="0"
                              Maximum="{Binding TotalAnswered}"
                              Value="{Binding TotalCorrect}"
                              Width="250"
-                             Foreground="LightBlue"
+                             Foreground="{StaticResource AccentBrush}"
                              CornerRadius="5"
                              HorizontalAlignment="Center"/>
                 <StackPanel Orientation="Horizontal" HorizontalAlignment="Center" Spacing="10">
@@ -168,7 +168,7 @@
                             Style="{StaticResource AccentButtonStyle}"/>
                     <Button Content="🛑 Beenden"
                             Command="{Binding CloseSessionCommand}"
-                            Background="HotPink" Foreground="White"
+                            Background="{StaticResource DangerBrush}" Foreground="White"
                             CornerRadius="8"/>
                 </StackPanel>
             </StackPanel>

--- a/NeoCardium/Views/SettingsPage.xaml
+++ b/NeoCardium/Views/SettingsPage.xaml
@@ -20,6 +20,7 @@
                 <ComboBoxItem Content="System" Tag="Default"/>
                 <ComboBoxItem Content="Hell" Tag="Light"/>
                 <ComboBoxItem Content="Dunkel" Tag="Dark"/>
+                <ComboBoxItem Content="Pastell" Tag="Pastel"/>
             </ComboBox>
         </StackPanel>
 

--- a/NeoCardium/Views/SettingsPage.xaml.cs
+++ b/NeoCardium/Views/SettingsPage.xaml.cs
@@ -40,10 +40,7 @@ namespace NeoCardium.Views
             
             DataContext = ViewModel;
 
-            if (Enum.TryParse<ElementTheme>(ViewModel.SelectedTheme, out var theme) && App._mainWindow?.Content is FrameworkElement root)
-            {
-                root.RequestedTheme = theme;
-            }
+            App.ApplyTheme(ViewModel.SelectedTheme);
         }
 
         private void LanguageComboBox_SelectionChanged(object sender, SelectionChangedEventArgs e)


### PR DESCRIPTION
## Summary
- create `Themes/Pastel.xaml` with pastel brushes
- add default color resources in `App.xaml`
- allow theme switching via `SettingsPage` and `ApplyTheme` helper in `App`
- replace hard-coded colors in pages with theme resources
- include pastel XAML in project file

## Testing
- `dotnet build -c Release` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684f51b1f550832e8d032d0516f3840a