### PR TITLE
Add new practice modes

### DIFF
--- a/NeoCardium/Models/PracticeMode.cs
+++ b/NeoCardium/Models/PracticeMode.cs
@@ -9,7 +9,10 @@ namespace NeoCardium.Models
     public enum PracticeMode
     {
         MultipleChoice,
-        Flashcard
+        Flashcard,
+        TypedAnswer,
+        Timed,
+        TrueFalse
     }
     public class PracticeModeOption
     {

--- a/NeoCardium/ViewModels/PracticePageViewModel.cs
+++ b/NeoCardium/ViewModels/PracticePageViewModel.cs
@@ -13,6 +13,7 @@ using Microsoft.UI.Xaml; // For XamlRoot access if needed
 using System.Windows.Input;
 using Microsoft.UI.Xaml.Controls;
 using NeoCardium.Views;
+using Microsoft.UI.Dispatching;
 
 namespace NeoCardium.ViewModels
 {
@@ -63,6 +64,11 @@ namespace NeoCardium.ViewModels
         private bool _isRetryModeEnabled;
         private bool _isFinalStatisticsVisible;
 
+        // Additional fields for new practice modes
+        private string _typedUserAnswer = string.Empty;
+        private int _timeLeft;
+        private DispatcherTimer? _timer;
+
         // Flag to prevent multiple rapid answer processing.
         private bool _isProcessingAnswer;
         public bool IsProcessingAnswer
@@ -78,6 +84,7 @@ namespace NeoCardium.ViewModels
 
         // Commands.
         public ICommand CheckAnswerAsync { get; }
+        public ICommand CheckTypedAnswerAsync { get; }
 
         public PracticePageViewModel()
         {
@@ -119,6 +126,8 @@ namespace NeoCardium.ViewModels
                 }
 
                 Debug.WriteLine($"[CheckAnswerAsync] Antwort geklickt: {selectedAnswer.AnswerText}");
+                if (SelectedMode == PracticeMode.Timed)
+                    StopTimer();
                 if (selectedAnswer.IsCorrect)
                 {
                     if (!_isRetryModeEnabled)
@@ -148,6 +157,49 @@ namespace NeoCardium.ViewModels
                     await Task.Delay(2000);
                 }
 
+                IsFeedbackVisible = false;
+                await LoadNextQuestionAsync();
+                IsProcessingAnswer = false;
+            });
+
+            // Command for TypedAnswer mode
+            CheckTypedAnswerAsync = new RelayCommand(async (_) =>
+            {
+                if (IsProcessingAnswer) return;
+                IsProcessingAnswer = true;
+
+                if (SelectedMode == PracticeMode.Timed)
+                    StopTimer();
+
+                string user = TypedUserAnswer?.Trim() ?? string.Empty;
+                string correct = CurrentQuestion.Answer.Trim();
+                bool correctFlag = string.Equals(user, correct, StringComparison.OrdinalIgnoreCase);
+
+                if (correctFlag)
+                {
+                    if (!_isRetryModeEnabled)
+                        _totalCorrect++;
+                    if (_incorrectQuestions.Contains(CurrentQuestion))
+                        _incorrectQuestions.Remove(CurrentQuestion);
+                    CurrentQuestion.UpdateCorrectCount();
+                    DatabaseHelper.Instance.UpdateFlashcardStats(CurrentQuestion.Id, true);
+                    FeedbackMessage = "✅ Richtig!";
+                    IsFeedbackVisible = true;
+                    await Task.Delay(750);
+                }
+                else
+                {
+                    _totalIncorrect++;
+                    if (!_incorrectQuestions.Contains(CurrentQuestion))
+                        _incorrectQuestions.Add(CurrentQuestion);
+                    CurrentQuestion.UpdateIncorrectCount();
+                    DatabaseHelper.Instance.UpdateFlashcardStats(CurrentQuestion.Id, false);
+                    FeedbackMessage = $"⚠ Falsch ⚠\nRichtige Antwort: {correct}";
+                    IsFeedbackVisible = true;
+                    await Task.Delay(2000);
+                }
+
+                TypedUserAnswer = string.Empty;
                 IsFeedbackVisible = false;
                 await LoadNextQuestionAsync();
                 IsProcessingAnswer = false;
@@ -200,15 +252,15 @@ namespace NeoCardium.ViewModels
                 Questions = new ObservableCollection<Flashcard>(selectedQuestions);
                 Debug.WriteLine($"[StartPracticeAsync] => Questions.Count={Questions.Count}");
 
-                if (SelectedMode == PracticeMode.MultipleChoice)
-                {
-                    Debug.WriteLine("[StartPracticeAsync] => Mode=MultipleChoice, calling LoadNextQuestionAsync()");
-                    await LoadNextQuestionAsync();
-                }
-                else if (SelectedMode == PracticeMode.Flashcard)
+                if (SelectedMode == PracticeMode.Flashcard)
                 {
                     Debug.WriteLine("[StartPracticeAsync] => Mode=Flashcard, calling LoadFlashcard()");
                     LoadFlashcard();
+                }
+                else
+                {
+                    Debug.WriteLine($"[StartPracticeAsync] => Mode={SelectedMode}, calling LoadNextQuestionAsync()");
+                    await LoadNextQuestionAsync();
                 }
 
                 IsSessionActive = true;
@@ -300,6 +352,7 @@ namespace NeoCardium.ViewModels
                 }
                 else
                 {
+                    StopTimer();
                     ResetPracticeSession();
                     IsSessionActive = false;
                     Debug.WriteLine("[TogglePracticeSessionAsync] => Session stopped");
@@ -328,6 +381,10 @@ namespace NeoCardium.ViewModels
             OnPropertyChanged(nameof(IsFinalStatisticsVisible));
             OnPropertyChanged(nameof(IsSessionActive));
 
+            StopTimer();
+            TypedUserAnswer = string.Empty;
+            TimeLeft = 0;
+
             // Reset selection: always choose the first category, if any.
             if (Categories != null && Categories.Count > 0)
                 SelectedCategory = Categories.First();
@@ -347,6 +404,7 @@ namespace NeoCardium.ViewModels
         public async Task RestartSessionAsync()
         {
             Debug.WriteLine("[RestartSessionAsync] => Hiding stats, restarting session");
+            StopTimer();
             IsFinalStatisticsVisible = false;
             IsSessionActive = true;
             OnPropertyChanged(nameof(IsFinalStatisticsVisible));
@@ -419,7 +477,24 @@ namespace NeoCardium.ViewModels
                 OnPropertyChanged(nameof(CurrentQuestion));
                 OnPropertyChanged(nameof(CurrentQuestion.Question));
                 OnPropertyChanged(nameof(CurrentQuestion.Answer));
-                LoadAnswers();
+
+                if (SelectedMode == PracticeMode.MultipleChoice || SelectedMode == PracticeMode.Timed)
+                {
+                    LoadAnswers();
+                }
+                else if (SelectedMode == PracticeMode.TrueFalse)
+                {
+                    LoadTrueFalseAnswers();
+                }
+                else if (SelectedMode == PracticeMode.TypedAnswer)
+                {
+                    TypedUserAnswer = string.Empty;
+                }
+
+                if (SelectedMode == PracticeMode.Timed)
+                {
+                    StartTimer();
+                }
             }
             catch (Exception ex)
             {
@@ -491,6 +566,47 @@ namespace NeoCardium.ViewModels
             OnPropertyChanged(nameof(AnswerButtonText));
         }
 
+        private void StartTimer()
+        {
+            StopTimer();
+            TimeLeft = 20;
+            _timer = new DispatcherTimer
+            {
+                Interval = TimeSpan.FromSeconds(1)
+            };
+            _timer.Tick += Timer_Tick;
+            _timer.Start();
+        }
+
+        private void StopTimer()
+        {
+            if (_timer != null)
+            {
+                _timer.Stop();
+                _timer.Tick -= Timer_Tick;
+                _timer = null;
+            }
+        }
+
+        private async void Timer_Tick(object sender, object e)
+        {
+            TimeLeft--;
+            if (TimeLeft <= 0)
+            {
+                StopTimer();
+                _totalIncorrect++;
+                if (!_incorrectQuestions.Contains(CurrentQuestion))
+                    _incorrectQuestions.Add(CurrentQuestion);
+                CurrentQuestion.UpdateIncorrectCount();
+                DatabaseHelper.Instance.UpdateFlashcardStats(CurrentQuestion.Id, false);
+                FeedbackMessage = "⏰ Zeit abgelaufen!";
+                IsFeedbackVisible = true;
+                await Task.Delay(1000);
+                IsFeedbackVisible = false;
+                await LoadNextQuestionAsync();
+            }
+        }
+
         /// <summary>
         /// Loads answer options for the current question.
         /// If none are found, shows an error message.
@@ -530,6 +646,23 @@ namespace NeoCardium.ViewModels
             OnPropertyChanged(nameof(AnswerButtonText));
         }
 
+        private void LoadTrueFalseAnswers()
+        {
+            AnswerOptions = new ObservableCollection<FlashcardAnswer>
+            {
+                new FlashcardAnswer
+                {
+                    AnswerText = "Wahr",
+                    IsCorrect = CurrentQuestion.Answer.Trim().ToLower() == "true"
+                },
+                new FlashcardAnswer
+                {
+                    AnswerText = "Falsch",
+                    IsCorrect = CurrentQuestion.Answer.Trim().ToLower() == "false"
+                }
+            };
+        }
+
         /// <summary>
         /// Displays the final statistics overlay.
         /// </summary>
@@ -538,6 +671,7 @@ namespace NeoCardium.ViewModels
             try
             {
                 Debug.WriteLine("[ShowFinalStatisticsAsync] => Setting IsSessionActive=false, IsFinalStatisticsVisible=true");
+                StopTimer();
                 IsSessionActive = false;
                 IsFinalStatisticsVisible = true;
                 OnPropertyChanged(nameof(IsSessionActive));
@@ -598,10 +732,27 @@ namespace NeoCardium.ViewModels
 
         public string AnswerButtonText => IsAnswerRevealed ? "Nächste Frage" : "Antwort anzeigen";
 
+        // Text entered by the user in TypedAnswer mode
+        public string TypedUserAnswer
+        {
+            get => _typedUserAnswer;
+            set => SetProperty(ref _typedUserAnswer, value);
+        }
+
+        // Remaining time for Timed mode
+        public int TimeLeft
+        {
+            get => _timeLeft;
+            set => SetProperty(ref _timeLeft, value);
+        }
+
         public ObservableCollection<PracticeModeOption> AvailableModes { get; } = new ObservableCollection<PracticeModeOption>
         {
             new PracticeModeOption { Mode = PracticeMode.MultipleChoice, ModeName = "Multiple-Choice" },
-            new PracticeModeOption { Mode = PracticeMode.Flashcard, ModeName = "Karteikarten-Modus" }
+            new PracticeModeOption { Mode = PracticeMode.Flashcard, ModeName = "Karteikarten-Modus" },
+            new PracticeModeOption { Mode = PracticeMode.TypedAnswer, ModeName = "Freitext" },
+            new PracticeModeOption { Mode = PracticeMode.Timed, ModeName = "Zeitmodus" },
+            new PracticeModeOption { Mode = PracticeMode.TrueFalse, ModeName = "Wahr/Falsch" }
         };
 
         public PracticeMode SelectedMode

--- a/NeoCardium/Views/PracticePage.xaml
+++ b/NeoCardium/Views/PracticePage.xaml
@@ -100,6 +100,36 @@
                         </ItemsControl.ItemTemplate>
                     </ItemsControl>
                 </StackPanel>
+
+                <!-- Timed-Modus (Multiple Choice mit Timer) -->
+                <StackPanel HorizontalAlignment="Center" VerticalAlignment="Top" Padding="20"
+                            Visibility="{Binding SelectedMode, Converter={StaticResource EnumToVisibilityConverter}, ConverterParameter=Timed}">
+                    <TextBlock Text="{Binding TimeLeft}" FontSize="20" Foreground="LightBlue" HorizontalAlignment="Center"/>
+                    <ItemsControl ItemsSource="{Binding AnswerOptions}">
+                        <ItemsControl.ItemsPanel>
+                            <ItemsPanelTemplate>
+                                <VariableSizedWrapGrid MaximumRowsOrColumns="2" Orientation="Horizontal" HorizontalAlignment="Center"/>
+                            </ItemsPanelTemplate>
+                        </ItemsControl.ItemsPanel>
+                        <ItemsControl.ItemTemplate>
+                            <DataTemplate>
+                                <Button Content="{Binding AnswerText}"
+                                            Command="{Binding DataContext.CheckAnswerAsync, ElementName=PracticePageView}"
+                                            CommandParameter="{Binding}"
+                                            Padding="20,10"
+                                            Margin="10, 15, 0, 0"
+                                            FontSize="18"
+                                            Background="#292929"
+                                            Foreground="White"
+                                            BorderBrush="LightBlue"
+                                            BorderThickness="2"
+                                            CornerRadius="15"
+                                            HorizontalAlignment="Stretch"
+                                            MinWidth="250"/>
+                            </DataTemplate>
+                        </ItemsControl.ItemTemplate>
+                    </ItemsControl>
+                </StackPanel>
             </Grid>
 
             <!-- Flashcard-Modus -->
@@ -121,6 +151,13 @@
                                FontSize="22" FontWeight="Bold" Foreground="White" 
                                TextWrapping="Wrap" HorizontalAlignment="Center"/>
                 </Border>
+            </StackPanel>
+
+            <!-- TypedAnswer-Modus -->
+            <StackPanel Grid.Row="2" HorizontalAlignment="Center" VerticalAlignment="Top" Spacing="10"
+                        Visibility="{Binding SelectedMode, Converter={StaticResource EnumToVisibilityConverter}, ConverterParameter=TypedAnswer}">
+                <TextBox Text="{Binding TypedUserAnswer, Mode=TwoWay}" Width="300" PlaceholderText="Antwort eingeben"/>
+                <Button Content="Prüfen" Command="{Binding CheckTypedAnswerAsync}" Width="150" IsEnabled="{Binding IsNotProcessing}"/>
             </StackPanel>
         </Grid>
 


### PR DESCRIPTION
## Summary
- extend `PracticeMode` enum
- expose more options in `PracticePageViewModel`
- implement logic for typed answers, timed questions and true/false
- update `PracticePage` UI for the new modes

## Testing
- `dotnet --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684f51ba27cc832eb92e55bdf63713c8