### PR TITLE
Add gamification stats

### DIFF
--- a/NeoCardium/App.xaml
+++ b/NeoCardium/App.xaml
@@ -24,6 +24,7 @@
             <converters:EnumToVisibilityConverter x:Key="BooleanToAnswerTextConverter"/>
             <converters:BooleanInverterConverter x:Key="BooleanInverterConverter"/>
             <converters:MultiBooleanToVisibilityConverter x:Key="MultiBooleanToVisibilityConverter"/>
+            <converters:StringToVisibilityConverter x:Key="StringToVisibilityConverter"/>
         </ResourceDictionary>
     </Application.Resources>
 </Application>

--- a/NeoCardium/Converters/StringToVisibilityConverter.cs
+++ b/NeoCardium/Converters/StringToVisibilityConverter.cs
@@ -1,0 +1,20 @@
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Data;
+using System;
+
+namespace NeoCardium.Converters
+{
+    public class StringToVisibilityConverter : IValueConverter
+    {
+        public object Convert(object value, Type targetType, object parameter, string language)
+        {
+            bool hasText = value is string str && !string.IsNullOrWhiteSpace(str);
+            return hasText ? Visibility.Visible : Visibility.Collapsed;
+        }
+
+        public object ConvertBack(object value, Type targetType, object parameter, string language)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/NeoCardium/Helpers/DatabaseHelper.cs
+++ b/NeoCardium/Helpers/DatabaseHelper.cs
@@ -389,5 +389,91 @@ namespace NeoCardium.Database
         }
 
         #endregion
+
+        #region Gamification Operations
+
+        private void EnsureGamificationTable(SqliteConnection db)
+        {
+            const string createTable = @"CREATE TABLE IF NOT EXISTS GamificationStats (
+                                        Id INTEGER PRIMARY KEY CHECK (Id = 1),
+                                        Points INTEGER NOT NULL DEFAULT 0,
+                                        Streak INTEGER NOT NULL DEFAULT 0,
+                                        Badges TEXT)";
+            using var cmd = new SqliteCommand(createTable, db);
+            cmd.ExecuteNonQuery();
+        }
+
+        public GamificationStats GetGamificationStats()
+        {
+            try
+            {
+                using var db = _database.GetConnection();
+                db.Open();
+                EnsureGamificationTable(db);
+
+                const string query = "SELECT Points, Streak, Badges FROM GamificationStats WHERE Id = 1";
+                using var cmd = new SqliteCommand(query, db);
+                using var reader = cmd.ExecuteReader();
+                if (reader.Read())
+                {
+                    var stats = new GamificationStats
+                    {
+                        Points = reader.GetInt32(0),
+                        Streak = reader.GetInt32(1),
+                        Badges = new ObservableCollection<string>((reader.IsDBNull(2) ? string.Empty : reader.GetString(2)).Split(',', StringSplitOptions.RemoveEmptyEntries))
+                    };
+                    return stats;
+                }
+                else
+                {
+                    var stats = new GamificationStats();
+                    SaveGamificationStats(stats);
+                    return stats;
+                }
+            }
+            catch (Exception ex)
+            {
+                ExceptionHelper.LogError("Fehler beim Laden der Gamification-Daten.", ex);
+                return new GamificationStats();
+            }
+        }
+
+        private void SaveGamificationStats(GamificationStats stats)
+        {
+            using var db = _database.GetConnection();
+            db.Open();
+            EnsureGamificationTable(db);
+
+            const string query = "INSERT OR REPLACE INTO GamificationStats (Id, Points, Streak, Badges) VALUES (1, @Points, @Streak, @Badges)";
+            using var cmd = new SqliteCommand(query, db);
+            cmd.Parameters.AddWithValue("@Points", stats.Points);
+            cmd.Parameters.AddWithValue("@Streak", stats.Streak);
+            cmd.Parameters.AddWithValue("@Badges", string.Join(',', stats.Badges));
+            cmd.ExecuteNonQuery();
+        }
+
+        public List<string> AddSessionResult(int correctAnswers, bool perfectSession)
+        {
+            var stats = GetGamificationStats();
+            stats.Points += correctAnswers;
+            stats.Streak = perfectSession ? stats.Streak + 1 : 0;
+
+            var newBadges = new List<string>();
+            if (stats.Points >= 50 && !stats.Badges.Contains("Rookie"))
+            {
+                stats.Badges.Add("Rookie");
+                newBadges.Add("Rookie");
+            }
+            if (stats.Points >= 200 && !stats.Badges.Contains("Pro"))
+            {
+                stats.Badges.Add("Pro");
+                newBadges.Add("Pro");
+            }
+
+            SaveGamificationStats(stats);
+            return newBadges;
+        }
+
+        #endregion
     }
 }

--- a/NeoCardium/Models/GamificationStats.cs
+++ b/NeoCardium/Models/GamificationStats.cs
@@ -1,0 +1,36 @@
+using System.Collections.ObjectModel;
+using System.ComponentModel;
+using System.Runtime.CompilerServices;
+
+namespace NeoCardium.Models
+{
+    public class GamificationStats : INotifyPropertyChanged
+    {
+        private int _points;
+        public int Points
+        {
+            get => _points;
+            set { _points = value; OnPropertyChanged(); }
+        }
+
+        private int _streak;
+        public int Streak
+        {
+            get => _streak;
+            set { _streak = value; OnPropertyChanged(); }
+        }
+
+        private ObservableCollection<string> _badges = new();
+        public ObservableCollection<string> Badges
+        {
+            get => _badges;
+            set { _badges = value; OnPropertyChanged(); }
+        }
+
+        public event PropertyChangedEventHandler? PropertyChanged;
+        protected void OnPropertyChanged([CallerMemberName] string propertyName = null!)
+        {
+            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+        }
+    }
+}

--- a/NeoCardium/ViewModels/PracticePageViewModel.cs
+++ b/NeoCardium/ViewModels/PracticePageViewModel.cs
@@ -48,6 +48,9 @@ namespace NeoCardium.ViewModels
         private int _totalCorrect;
         private int _totalIncorrect;
 
+        private GamificationStats _stats;
+        private string _achievementMessage;
+
         // Data collections and current state.
         private ObservableCollection<Category> _categories;
         private Category? _selectedCategory;
@@ -103,6 +106,8 @@ namespace NeoCardium.ViewModels
             _isSessionActive = false;
             _isRetryModeEnabled = false;
             _isFinalStatisticsVisible = false;
+            _stats = DatabaseHelper.Instance.GetGamificationStats();
+            _achievementMessage = string.Empty;
             IsProcessingAnswer = false;
 
             // Command to process answer clicks.
@@ -547,6 +552,10 @@ namespace NeoCardium.ViewModels
                 OnPropertyChanged(nameof(TotalCorrect));
                 OnPropertyChanged(nameof(TotalAnswered));
 
+                var newBadges = DatabaseHelper.Instance.AddSessionResult(TotalCorrect, TotalIncorrect == 0);
+                Stats = DatabaseHelper.Instance.GetGamificationStats();
+                AchievementMessage = newBadges.Count > 0 ? $"Neue Abzeichen: {string.Join(", ", newBadges)}" : string.Empty;
+
                 await Task.Delay(500);
             }
             catch (Exception ex)
@@ -633,6 +642,18 @@ namespace NeoCardium.ViewModels
         }
 
         public int TotalAnswered => TotalCorrect + TotalIncorrect;
+
+        public GamificationStats Stats
+        {
+            get => _stats;
+            set => SetProperty(ref _stats, value);
+        }
+
+        public string AchievementMessage
+        {
+            get => _achievementMessage;
+            set => SetProperty(ref _achievementMessage, value);
+        }
 
         public string FeedbackMessage
         {

--- a/NeoCardium/Views/PracticePage.xaml
+++ b/NeoCardium/Views/PracticePage.xaml
@@ -28,6 +28,13 @@
             <!-- row=2 -->
         </Grid.RowDefinitions>
 
+        <StackPanel Grid.Row="0" Orientation="Horizontal" HorizontalAlignment="Center" Spacing="20">
+            <TextBlock Text="🏆 Punkte:" Foreground="LightBlue" FontSize="18"/>
+            <TextBlock Text="{Binding Stats.Points}" Foreground="LightBlue" FontSize="18" FontWeight="Bold" Margin="5,0,20,0"/>
+            <TextBlock Text="🔥 Streak:" Foreground="Orange" FontSize="18"/>
+            <TextBlock Text="{Binding Stats.Streak}" Foreground="Orange" FontSize="18" FontWeight="Bold" Margin="5,0,0,0"/>
+        </StackPanel>
+
         <!-- row 1: Kategorie- und Modus-Auswahl -->
         <StackPanel Grid.Row="1" HorizontalAlignment="Center" VerticalAlignment="Center"
                     Visibility="{Binding IsCategorySelectionVisible, Converter={StaticResource BooleanToVisibilityConverter}}">
@@ -162,6 +169,10 @@
                              Foreground="LightBlue"
                              CornerRadius="5"
                              HorizontalAlignment="Center"/>
+                <TextBlock Text="{Binding AchievementMessage}"
+                           Foreground="LightBlue" FontSize="18" FontWeight="Bold"
+                           Visibility="{Binding AchievementMessage, Converter={StaticResource StringToVisibilityConverter}}"
+                           HorizontalAlignment="Center"/>
                 <StackPanel Orientation="Horizontal" HorizontalAlignment="Center" Spacing="10">
                     <Button Content="🔄 Erneut üben"
                             Command="{Binding RestartSessionCommand}"


### PR DESCRIPTION
## Summary
- track user points, streak and badges via new `GamificationStats` model
- persist gamification data in `DatabaseHelper`
- show points/streak on `PracticePage`
- display achievement text for earned badges
- add converter for visibility of achievement text

## Testing
- `dotnet build NeoCardium/NeoCardium.csproj -c Release` *(fails: dotnet not found)*

------
https://chatgpt.com/codex/tasks/task_e_684f51c03338832e8e908dfebca29a3e