### PR TITLE
Add statistics history page with charts

### DIFF
--- a/NeoCardium/Database/Database.cs
+++ b/NeoCardium/Database/Database.cs
@@ -70,12 +70,21 @@ namespace NeoCardium.Database
                                     IsCorrect INTEGER NOT NULL CHECK (IsCorrect IN (0,1)),
                                     FOREIGN KEY (FlashcardId) REFERENCES Flashcards(Id) ON DELETE CASCADE)";
 
+                string createFlashcardStatsTable = @"CREATE TABLE IF NOT EXISTS FlashcardStats (
+                                    Id INTEGER PRIMARY KEY AUTOINCREMENT,
+                                    FlashcardId INTEGER NOT NULL,
+                                    IsCorrect INTEGER NOT NULL CHECK (IsCorrect IN (0,1)),
+                                    AnswerDate TEXT NOT NULL,
+                                    FOREIGN KEY (FlashcardId) REFERENCES Flashcards(Id) ON DELETE CASCADE)";
+
                 using var cmd1 = new SqliteCommand(createCategoriesTable, db);
                 cmd1.ExecuteNonQuery();
                 using var cmd2 = new SqliteCommand(createFlashcardsTable, db);
                 cmd2.ExecuteNonQuery();
                 using var cmd3 = new SqliteCommand(createFlashcardAnswersTable, db);
                 cmd3.ExecuteNonQuery();
+                using var cmd4 = new SqliteCommand(createFlashcardStatsTable, db);
+                cmd4.ExecuteNonQuery();
 
                 ExceptionHelper.LogError($"[SUCCESS] Datenbank erfolgreich initialisiert: {_dbPath}");
             }

--- a/NeoCardium/Helpers/DatabaseHelper.cs
+++ b/NeoCardium/Helpers/DatabaseHelper.cs
@@ -379,12 +379,85 @@ namespace NeoCardium.Database
                 using var command = new SqliteCommand(query, db);
                 command.Parameters.AddWithValue("@FlashcardId", flashcardId);
                 command.ExecuteNonQuery();
+
+                string insertStat = "INSERT INTO FlashcardStats (FlashcardId, IsCorrect, AnswerDate) VALUES (@FlashcardId, @IsCorrect, @AnswerDate)";
+                using var statCmd = new SqliteCommand(insertStat, db);
+                statCmd.Parameters.AddWithValue("@FlashcardId", flashcardId);
+                statCmd.Parameters.AddWithValue("@IsCorrect", isCorrect ? 1 : 0);
+                statCmd.Parameters.AddWithValue("@AnswerDate", DateTime.UtcNow.ToString("o"));
+                statCmd.ExecuteNonQuery();
                 return true;
             }
             catch (Exception ex)
             {
                 ExceptionHelper.LogError("Fehler beim Aktualisieren der Statistik.", ex);
                 return false;
+            }
+        }
+
+        public bool ResetStatistics()
+        {
+            try
+            {
+                using var db = _database.GetConnection();
+                db.Open();
+                using var cmd = new SqliteCommand("DELETE FROM FlashcardStats", db);
+                cmd.ExecuteNonQuery();
+                using var resetCmd = new SqliteCommand("UPDATE Flashcards SET CorrectCount = 0, IncorrectCount = 0", db);
+                resetCmd.ExecuteNonQuery();
+                return true;
+            }
+            catch (Exception ex)
+            {
+                ExceptionHelper.LogError("Fehler beim Zurücksetzen der Statistik.", ex);
+                return false;
+            }
+        }
+
+        public List<DailyStat> GetDailyStatistics()
+        {
+            var stats = new List<DailyStat>();
+            try
+            {
+                using var db = _database.GetConnection();
+                db.Open();
+                string query = "SELECT date(AnswerDate) as Day, SUM(case when IsCorrect=1 then 1 else 0 end), SUM(case when IsCorrect=0 then 1 else 0 end) FROM FlashcardStats GROUP BY Day ORDER BY Day";
+                using var command = new SqliteCommand(query, db);
+                using var reader = command.ExecuteReader();
+                while (reader.Read())
+                {
+                    stats.Add(new DailyStat
+                    {
+                        Date = DateTime.Parse(reader.GetString(0)),
+                        Correct = reader.GetInt32(1),
+                        Incorrect = reader.GetInt32(2)
+                    });
+                }
+            }
+            catch (Exception ex)
+            {
+                ExceptionHelper.LogError("Fehler beim Abrufen der Statistik.", ex);
+            }
+            return stats;
+        }
+
+        public string ExportStatisticsCsv()
+        {
+            try
+            {
+                var stats = GetDailyStatistics();
+                var sb = new System.Text.StringBuilder();
+                sb.AppendLine("Date,Correct,Incorrect");
+                foreach (var s in stats)
+                {
+                    sb.AppendLine($"{s.Date:yyyy-MM-dd},{s.Correct},{s.Incorrect}");
+                }
+                return sb.ToString();
+            }
+            catch (Exception ex)
+            {
+                ExceptionHelper.LogError("Fehler beim Exportieren der Statistik.", ex);
+                return string.Empty;
             }
         }
 

--- a/NeoCardium/MainWindow.xaml
+++ b/NeoCardium/MainWindow.xaml
@@ -24,6 +24,12 @@
                 </NavigationViewItem.Icon>
             </NavigationViewItem>
 
+            <NavigationViewItem x:Uid="NavItem_Stats" Tag="StatsPage">
+                <NavigationViewItem.Icon>
+                    <SymbolIcon Symbol="Preview"/>
+                </NavigationViewItem.Icon>
+            </NavigationViewItem>
+
             <NavigationViewItem x:Uid="NavItem_Settings" Tag="SettingsPage">
                 <NavigationViewItem.Icon>
                     <SymbolIcon Symbol="Setting"/>

--- a/NeoCardium/MainWindow.xaml.cs
+++ b/NeoCardium/MainWindow.xaml.cs
@@ -41,6 +41,9 @@ namespace NeoCardium
                     case "PracticePage":
                         ContentFrame.Navigate(typeof(PracticePage));
                         break;
+                    case "StatsPage":
+                        ContentFrame.Navigate(typeof(StatsPage));
+                        break;
                     case "SettingsPage":
                         ContentFrame.Navigate(typeof(SettingsPage));
                         break;

--- a/NeoCardium/Models/DailyStat.cs
+++ b/NeoCardium/Models/DailyStat.cs
@@ -1,0 +1,9 @@
+namespace NeoCardium.Models
+{
+    public class DailyStat
+    {
+        public DateTime Date { get; set; }
+        public int Correct { get; set; }
+        public int Incorrect { get; set; }
+    }
+}

--- a/NeoCardium/Models/FlashcardStat.cs
+++ b/NeoCardium/Models/FlashcardStat.cs
@@ -1,0 +1,10 @@
+namespace NeoCardium.Models
+{
+    public class FlashcardStat
+    {
+        public int Id { get; set; }
+        public int FlashcardId { get; set; }
+        public bool IsCorrect { get; set; }
+        public DateTime AnswerDate { get; set; }
+    }
+}

--- a/NeoCardium/NeoCardium.csproj
+++ b/NeoCardium/NeoCardium.csproj
@@ -51,6 +51,7 @@
   
   <ItemGroup>
     <PackageReference Include="CommunityToolkit.Mvvm" Version="8.4.0" />
+    <PackageReference Include="CommunityToolkit.WinUI.UI.Controls" Version="8.2.1" />
     <PackageReference Include="Microsoft.Data.Sqlite" Version="9.0.2" />
     <PackageReference Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.26100.1742" />
     <PackageReference Include="Microsoft.WindowsAppSDK" Version="1.6.250205002" />
@@ -92,6 +93,11 @@
   </ItemGroup>
   <ItemGroup>
     <Page Update="Views\PracticePage.xaml">
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
+  </ItemGroup>
+  <ItemGroup>
+    <Page Update="Views\StatsPage.xaml">
       <Generator>MSBuild:Compile</Generator>
     </Page>
   </ItemGroup>

--- a/NeoCardium/Strings/de-DE/Resources.resw
+++ b/NeoCardium/Strings/de-DE/Resources.resw
@@ -6,6 +6,9 @@
   <data name="NavItem_Practice.Content" xml:space="preserve">
     <value>Lernmodus</value>
   </data>
+  <data name="NavItem_Stats.Content" xml:space="preserve">
+    <value>Statistik</value>
+  </data>
   <data name="NavItem_Settings.Content" xml:space="preserve">
     <value>Einstellungen</value>
   </data>

--- a/NeoCardium/Strings/en-US/Resources.resw
+++ b/NeoCardium/Strings/en-US/Resources.resw
@@ -6,6 +6,9 @@
   <data name="NavItem_Practice.Content" xml:space="preserve">
     <value>Practice</value>
   </data>
+  <data name="NavItem_Stats.Content" xml:space="preserve">
+    <value>Statistics</value>
+  </data>
   <data name="NavItem_Settings.Content" xml:space="preserve">
     <value>Settings</value>
   </data>

--- a/NeoCardium/ViewModels/StatsPageViewModel.cs
+++ b/NeoCardium/ViewModels/StatsPageViewModel.cs
@@ -1,0 +1,51 @@
+using System.Collections.ObjectModel;
+using System.Threading.Tasks;
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using NeoCardium.Database;
+using NeoCardium.Models;
+using Windows.Storage.Pickers;
+using WinRT.Interop;
+
+namespace NeoCardium.ViewModels
+{
+    public partial class StatsPageViewModel : ObservableObject
+    {
+        public ObservableCollection<DailyStat> DailyStats { get; } = new();
+
+        [RelayCommand]
+        private void LoadStats()
+        {
+            DailyStats.Clear();
+            foreach (var stat in DatabaseHelper.Instance.GetDailyStatistics())
+            {
+                DailyStats.Add(stat);
+            }
+        }
+
+        [RelayCommand]
+        private async Task ExportStatsAsync()
+        {
+            var csv = DatabaseHelper.Instance.ExportStatisticsCsv();
+            FileSavePicker savePicker = new();
+            savePicker.FileTypeChoices.Add("CSV", new() { ".csv" });
+            savePicker.SuggestedFileName = "statistics.csv";
+            var hwnd = WindowNative.GetWindowHandle(App._mainWindow);
+            InitializeWithWindow.Initialize(savePicker, hwnd);
+            var file = await savePicker.PickSaveFileAsync();
+            if (file != null)
+            {
+                await Windows.Storage.FileIO.WriteTextAsync(file, csv);
+            }
+        }
+
+        [RelayCommand]
+        private void ResetStats()
+        {
+            if (DatabaseHelper.Instance.ResetStatistics())
+            {
+                LoadStats();
+            }
+        }
+    }
+}

--- a/NeoCardium/Views/StatsPage.xaml
+++ b/NeoCardium/Views/StatsPage.xaml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Page
+    x:Class="NeoCardium.Views.StatsPage"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    xmlns:charting="using:CommunityToolkit.WinUI.UI.Controls"
+    mc:Ignorable="d"
+    xmlns:vm="using:NeoCardium.ViewModels"
+    x:DataType="vm:StatsPageViewModel">
+
+    <StackPanel Padding="20" Spacing="20">
+        <TextBlock Text="Learning History" FontSize="24" FontWeight="Bold"/>
+        <charting:Chart x:Name="HistoryChart" Height="300" ItemsSource="{x:Bind DailyStats}">
+            <charting:LineSeries ItemsSource="{x:Bind DailyStats}" IndependentValuePath="Date" DependentValuePath="Correct" Title="Correct"/>
+            <charting:LineSeries ItemsSource="{x:Bind DailyStats}" IndependentValuePath="Date" DependentValuePath="Incorrect" Title="Incorrect"/>
+        </charting:Chart>
+        <StackPanel Orientation="Horizontal" HorizontalAlignment="Center" Spacing="10">
+            <Button Content="Reset" Command="{x:Bind ViewModel.ResetStatsCommand}"/>
+            <Button Content="Export" Command="{x:Bind ViewModel.ExportStatsCommand}"/>
+        </StackPanel>
+    </StackPanel>
+</Page>

--- a/NeoCardium/Views/StatsPage.xaml.cs
+++ b/NeoCardium/Views/StatsPage.xaml.cs
@@ -1,0 +1,12 @@
+using Microsoft.UI.Xaml.Controls;
+
+namespace NeoCardium.Views
+{
+    public sealed partial class StatsPage : Page
+    {
+        public StatsPage()
+        {
+            this.InitializeComponent();
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- track answers in new `FlashcardStats` table
- expose statistics operations via `DatabaseHelper`
- create `StatsPage` and view model showing a line chart
- hook up export/reset commands
- add navigation entry for Statistics and localize strings
- reference CommunityToolkit charting controls

## Testing
- `dotnet build NeoCardium.sln -c Release` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684f51cd45b8832e93bec4b1c46233e3