### PR TITLE
Add search filter for categories and flashcards

### DIFF
--- a/NeoCardium/Strings/de-DE/Resources.resw
+++ b/NeoCardium/Strings/de-DE/Resources.resw
@@ -57,4 +57,7 @@
   <data name="CategoryDialog_SaveError.Text" xml:space="preserve">
     <value>Unerwarteter Fehler beim Speichern.</value>
   </data>
+  <data name="SearchBox.PlaceholderText" xml:space="preserve">
+    <value>Suchen</value>
+  </data>
 </root>

--- a/NeoCardium/Strings/en-US/Resources.resw
+++ b/NeoCardium/Strings/en-US/Resources.resw
@@ -57,4 +57,7 @@
   <data name="CategoryDialog_SaveError.Text" xml:space="preserve">
     <value>Unexpected error while saving.</value>
   </data>
+  <data name="SearchBox.PlaceholderText" xml:space="preserve">
+    <value>Search</value>
+  </data>
 </root>

--- a/NeoCardium/ViewModels/CategoryPageViewModel.cs
+++ b/NeoCardium/ViewModels/CategoryPageViewModel.cs
@@ -33,6 +33,21 @@ namespace NeoCardium.ViewModels
 
         public ObservableCollection<Category> Categories { get; } = new ObservableCollection<Category>();
 
+        private List<Category> _allCategories = new();
+
+        private string _searchText = string.Empty;
+        public string SearchText
+        {
+            get => _searchText;
+            set
+            {
+                if (SetProperty(ref _searchText, value, nameof(SearchText)))
+                {
+                    ApplyFilter();
+                }
+            }
+        }
+
         public ICommand DeleteCategoryCommand { get; }
         public ICommand DeleteSelectedCategoriesCommand { get; }
         public ICommand ExportCategoriesCommand { get; }
@@ -50,12 +65,22 @@ namespace NeoCardium.ViewModels
         public async Task LoadCategoriesAsync()
         {
             var cats = DatabaseHelper.Instance.GetCategories();
+            _allCategories = cats.ToList();
+            ApplyFilter();
+            await Task.CompletedTask;
+        }
+
+        private void ApplyFilter()
+        {
+            var filtered = string.IsNullOrWhiteSpace(SearchText)
+                ? _allCategories
+                : _allCategories.Where(c => c.CategoryName.Contains(SearchText, StringComparison.OrdinalIgnoreCase));
+
             Categories.Clear();
-            foreach (var cat in cats)
+            foreach (var cat in filtered)
             {
                 Categories.Add(cat);
             }
-            await Task.CompletedTask;
         }
 
         public void AddCategory(string categoryName)

--- a/NeoCardium/ViewModels/FlashcardsPageViewModel.cs
+++ b/NeoCardium/ViewModels/FlashcardsPageViewModel.cs
@@ -14,6 +14,21 @@ namespace NeoCardium.ViewModels
     {
         public ObservableCollection<Flashcard> Flashcards { get; } = new ObservableCollection<Flashcard>();
 
+        private List<Flashcard> _allFlashcards = new();
+
+        private string _searchText = string.Empty;
+        public string SearchText
+        {
+            get => _searchText;
+            set
+            {
+                if (SetProperty(ref _searchText, value))
+                {
+                    ApplyFilter();
+                }
+            }
+        }
+
         private int _selectedCategoryId;
         public int SelectedCategoryId
         {
@@ -34,12 +49,22 @@ namespace NeoCardium.ViewModels
         {
             SelectedCategoryId = categoryId;
             var flashcards = DatabaseHelper.Instance.GetFlashcardsByCategory(categoryId);
+            _allFlashcards = flashcards.ToList();
+            ApplyFilter();
+            await Task.CompletedTask;
+        }
+
+        private void ApplyFilter()
+        {
+            var filtered = string.IsNullOrWhiteSpace(SearchText)
+                ? _allFlashcards
+                : _allFlashcards.Where(f => f.Question.Contains(SearchText, System.StringComparison.OrdinalIgnoreCase));
+
             Flashcards.Clear();
-            foreach (var card in flashcards)
+            foreach (var card in filtered)
             {
                 Flashcards.Add(card);
             }
-            await Task.CompletedTask;
         }
 
         private async Task DeleteFlashcardAsync(Flashcard? flashcard)

--- a/NeoCardium/Views/CategoryPage.xaml
+++ b/NeoCardium/Views/CategoryPage.xaml
@@ -27,6 +27,7 @@
     <Grid Padding="20">
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
             <RowDefinition Height="*"/>
             <RowDefinition Height="Auto"/>
         </Grid.RowDefinitions>
@@ -36,7 +37,12 @@
                    FontWeight="Bold"
                    Margin="0,0,0,10"/>
 
-        <ScrollViewer Grid.Row="1">
+        <TextBox x:Uid="SearchBox"
+                 Text="{x:Bind ViewModel.SearchText, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
+                 Grid.Row="1"
+                 Margin="0,0,0,10"/>
+
+        <ScrollViewer Grid.Row="2">
             <ListView x:Name="CategoryListView"
                       SelectionMode="Extended"
                       IsItemClickEnabled="True"
@@ -53,7 +59,7 @@
         </ScrollViewer>
 
         <!-- Bottom row with two buttons: "Neue Kategorie erstellen" and "Import" -->
-        <Grid Grid.Row="2">
+        <Grid Grid.Row="3">
             <Grid.ColumnDefinitions>
                 <ColumnDefinition Width="Auto"/>
                 <ColumnDefinition Width="*"/>

--- a/NeoCardium/Views/FlashcardsPage.xaml
+++ b/NeoCardium/Views/FlashcardsPage.xaml
@@ -27,9 +27,8 @@
     -->
     <Grid Padding="10">
         <Grid.RowDefinitions>
-            <!-- The first two rows auto-size to their content -->
             <RowDefinition Height="Auto"/>
-            <!-- The last row takes the remaining space (star layout) -->
+            <RowDefinition Height="Auto"/>
             <RowDefinition Height="*"/>
         </Grid.RowDefinitions>
 
@@ -59,10 +58,15 @@
                     Click="BatchCreateButton_Click"/>
         </StackPanel>
 
-        <!-- Row 1: The ListView. 
+        <TextBox x:Uid="SearchBox"
+                 Text="{x:Bind ViewModel.SearchText, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
+                 Grid.Row="1"
+                 Margin="0,0,0,10"/>
+
+        <!-- Row 2: The ListView.
              Because it's in a star row, it will scroll automatically when items exceed the available space. -->
-        <ListView x:Name="FlashcardsListView" 
-                  ItemsSource="{x:Bind ViewModel.Flashcards}" 
+        <ListView x:Name="FlashcardsListView"
+                  ItemsSource="{x:Bind ViewModel.Flashcards}"
                   SelectionMode="Extended"
                   IsRightTapEnabled="True"
                   RightTapped="FlashcardsListView_RightTapped"


### PR DESCRIPTION
## Summary
- add `SearchBox` string to resource files
- add search text/filter logic to `CategoryPageViewModel` and `FlashcardsPageViewModel`
- show search boxes on `CategoryPage` and `FlashcardsPage`

## Testing
- `dotnet build` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684f51d2cf18832e908b2d75f71d43ff