### PR TITLE
Add onboarding tutorial

### DIFF
--- a/NeoCardium/App.xaml.cs
+++ b/NeoCardium/App.xaml.cs
@@ -4,12 +4,14 @@ using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Navigation;
 using NeoCardium.Helpers;
 using NeoCardium.Database;
+using Windows.Storage;
 
 namespace NeoCardium
 {
     public partial class App : Application
     {
         public static MainWindow? _mainWindow { get; private set; }
+        private const string FirstLaunchKey = "FirstLaunchShown";
 
         public App()
         {
@@ -41,6 +43,19 @@ namespace NeoCardium
             {
                 _mainWindow = new MainWindow();
                 _mainWindow.Activate();
+            }
+
+            var localSettings = ApplicationData.Current.LocalSettings;
+            bool isFirstLaunch = false;
+            if (!localSettings.Values.ContainsKey(FirstLaunchKey))
+            {
+                isFirstLaunch = true;
+                localSettings.Values[FirstLaunchKey] = true;
+            }
+
+            if (isFirstLaunch)
+            {
+                _mainWindow.NavigateToTutorial();
             }
         }
     }

--- a/NeoCardium/MainWindow.xaml.cs
+++ b/NeoCardium/MainWindow.xaml.cs
@@ -77,5 +77,15 @@ namespace NeoCardium
                 micaController = null;
             };
         }
+
+        public void NavigateToTutorial()
+        {
+            ContentFrame.Navigate(typeof(TutorialPage));
+        }
+
+        public void NavigateToCategory()
+        {
+            ContentFrame.Navigate(typeof(CategoryPage));
+        }
     }
 }

--- a/NeoCardium/NeoCardium.csproj
+++ b/NeoCardium/NeoCardium.csproj
@@ -103,6 +103,11 @@
       <Generator>MSBuild:Compile</Generator>
     </Page>
   </ItemGroup>
+  <ItemGroup>
+    <Page Update="Views\TutorialPage.xaml">
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
+  </ItemGroup>
 
   <!-- Enable Package and Publish context menu if using MSIX tooling -->
   <PropertyGroup Condition="'$(DisableHasPackageAndPublishMenuAddedByProject)'!='true' and '$(EnableMsixTooling)'=='true'">

--- a/NeoCardium/Strings/de-DE/Resources.resw
+++ b/NeoCardium/Strings/de-DE/Resources.resw
@@ -57,4 +57,22 @@
   <data name="CategoryDialog_SaveError.Text" xml:space="preserve">
     <value>Unerwarteter Fehler beim Speichern.</value>
   </data>
+  <data name="SettingsPage_ReplayTutorialButton.Content" xml:space="preserve">
+    <value>Tutorial anzeigen</value>
+  </data>
+  <data name="TutorialPage_Step1.Title" xml:space="preserve">
+    <value>Kategorien erstellen</value>
+  </data>
+  <data name="TutorialPage_Step1.Subtitle" xml:space="preserve">
+    <value>Lege Kategorien an, um deine Karten zu ordnen.</value>
+  </data>
+  <data name="TutorialPage_Step2.Title" xml:space="preserve">
+    <value>Lernen starten</value>
+  </data>
+  <data name="TutorialPage_Step2.Subtitle" xml:space="preserve">
+    <value>Wähle eine Kategorie und beginne mit dem Lernen.</value>
+  </data>
+  <data name="TutorialPage_FinishButton.Content" xml:space="preserve">
+    <value>Los geht's</value>
+  </data>
 </root>

--- a/NeoCardium/Strings/en-US/Resources.resw
+++ b/NeoCardium/Strings/en-US/Resources.resw
@@ -57,4 +57,22 @@
   <data name="CategoryDialog_SaveError.Text" xml:space="preserve">
     <value>Unexpected error while saving.</value>
   </data>
+  <data name="SettingsPage_ReplayTutorialButton.Content" xml:space="preserve">
+    <value>Show Tutorial</value>
+  </data>
+  <data name="TutorialPage_Step1.Title" xml:space="preserve">
+    <value>Create Categories</value>
+  </data>
+  <data name="TutorialPage_Step1.Subtitle" xml:space="preserve">
+    <value>Add categories to organize your flashcards.</value>
+  </data>
+  <data name="TutorialPage_Step2.Title" xml:space="preserve">
+    <value>Start Practice</value>
+  </data>
+  <data name="TutorialPage_Step2.Subtitle" xml:space="preserve">
+    <value>Select a category and begin practicing.</value>
+  </data>
+  <data name="TutorialPage_FinishButton.Content" xml:space="preserve">
+    <value>Get Started</value>
+  </data>
 </root>

--- a/NeoCardium/Views/SettingsPage.xaml
+++ b/NeoCardium/Views/SettingsPage.xaml
@@ -43,5 +43,8 @@
             <TextBlock Text="Konto" FontWeight="SemiBold" Margin="0,10,0,5"/>
             <TextBlock Text="{x:Bind ViewModel.LicenseStatus}"/>
         </StackPanel>
+
+        <Button x:Uid="SettingsPage_ReplayTutorialButton"
+                Click="ReplayTutorial_Click"/>
     </StackPanel>
 </Page>

--- a/NeoCardium/Views/SettingsPage.xaml.cs
+++ b/NeoCardium/Views/SettingsPage.xaml.cs
@@ -54,5 +54,10 @@ namespace NeoCardium.Views
                 Windows.ApplicationModel.Resources.Core.ResourceContext.GetForCurrentView().Reset();
             }
         }
+
+        private void ReplayTutorial_Click(object sender, RoutedEventArgs e)
+        {
+            App._mainWindow?.NavigateToTutorial();
+        }
     }
 }

--- a/NeoCardium/Views/TutorialPage.xaml
+++ b/NeoCardium/Views/TutorialPage.xaml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Page
+    x:Class="NeoCardium.Views.TutorialPage"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    mc:Ignorable="d"
+    Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+    <Grid>
+        <TeachingTip x:Name="TipCreate" Title="{x:Uid TutorialPage_Step1.Title}" Subtitle="{x:Uid TutorialPage_Step1.Subtitle}" IsOpen="False" Closed="TipCreate_Closed" />
+        <TeachingTip x:Name="TipPractice" Title="{x:Uid TutorialPage_Step2.Title}" Subtitle="{x:Uid TutorialPage_Step2.Subtitle}" IsOpen="False" Closed="TipPractice_Closed" />
+        <Button x:Name="FinishButton" Content="{x:Uid TutorialPage_FinishButton}" Visibility="Collapsed" Click="FinishButton_Click" HorizontalAlignment="Center" VerticalAlignment="Bottom" Margin="0,0,0,40"/>
+    </Grid>
+</Page>

--- a/NeoCardium/Views/TutorialPage.xaml.cs
+++ b/NeoCardium/Views/TutorialPage.xaml.cs
@@ -1,0 +1,37 @@
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+
+namespace NeoCardium.Views
+{
+    public sealed partial class TutorialPage : Page
+    {
+        public TutorialPage()
+        {
+            this.InitializeComponent();
+            Loaded += TutorialPage_Loaded;
+        }
+
+        private void TutorialPage_Loaded(object sender, RoutedEventArgs e)
+        {
+            TipCreate.IsOpen = true;
+        }
+
+        private void TipCreate_Closed(TeachingTip sender, TeachingTipClosedEventArgs args)
+        {
+            TipPractice.IsOpen = true;
+        }
+
+        private void TipPractice_Closed(TeachingTip sender, TeachingTipClosedEventArgs args)
+        {
+            FinishButton.Visibility = Visibility.Visible;
+        }
+
+        private void FinishButton_Click(object sender, RoutedEventArgs e)
+        {
+            if (Window.GetWindow(this) is MainWindow main)
+            {
+                main.NavigateToCategory();
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- detect first launch using `ApplicationData.LocalSettings`
- show a `TutorialPage` with teaching tips
- allow replaying the tutorial from settings

## Testing
- `dotnet build NeoCardium/NeoCardium.csproj -c Release` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684f51d911d0832e838e868ddaa4814a