### PR TITLE
Add daily reminder notifications

### DIFF
--- a/NeoCardium/App.xaml.cs
+++ b/NeoCardium/App.xaml.cs
@@ -4,6 +4,8 @@ using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Navigation;
 using NeoCardium.Helpers;
 using NeoCardium.Database;
+using NeoCardium.Services;
+using Windows.Storage;
 
 namespace NeoCardium
 {
@@ -41,6 +43,17 @@ namespace NeoCardium
             {
                 _mainWindow = new MainWindow();
                 _mainWindow.Activate();
+            }
+
+            var settings = ApplicationData.Current.LocalSettings;
+            if (settings.Values.TryGetValue("ReminderEnabled", out var enabledObj) && enabledObj is bool enabled && enabled)
+            {
+                TimeSpan time = new(9, 0, 0);
+                if (settings.Values.TryGetValue("ReminderTime", out var timeObj) && timeObj is string timeStr && TimeSpan.TryParse(timeStr, out var parsed))
+                {
+                    time = parsed;
+                }
+                ReminderService.ScheduleDailyReminder(time);
             }
         }
     }

--- a/NeoCardium/NeoCardium.csproj
+++ b/NeoCardium/NeoCardium.csproj
@@ -54,6 +54,7 @@
     <PackageReference Include="Microsoft.Data.Sqlite" Version="9.0.2" />
     <PackageReference Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.26100.1742" />
     <PackageReference Include="Microsoft.WindowsAppSDK" Version="1.6.250205002" />
+    <PackageReference Include="CommunityToolkit.WinUI.Notifications" Version="8.1.0" />
   </ItemGroup>
   
   <ItemGroup>

--- a/NeoCardium/Services/ReminderService.cs
+++ b/NeoCardium/Services/ReminderService.cs
@@ -1,0 +1,44 @@
+using System;
+using System.Linq;
+using Windows.UI.Notifications;
+using CommunityToolkit.WinUI.Notifications;
+
+namespace NeoCardium.Services
+{
+    public static class ReminderService
+    {
+        private const string ToastTag = "DailyReminder";
+
+        public static void ScheduleDailyReminder(TimeSpan time)
+        {
+            var notifier = ToastNotificationManager.CreateToastNotifier();
+            foreach (var scheduled in notifier.GetScheduledToastNotifications().Where(t => t.Tag == ToastTag).ToList())
+            {
+                notifier.RemoveFromSchedule(scheduled);
+            }
+
+            var next = DateTime.Today.Add(time);
+            if (next <= DateTime.Now)
+            {
+                next = next.AddDays(1);
+            }
+
+            var xml = new ToastContentBuilder()
+                .AddText("NeoCardium")
+                .AddText("Zeit zum Lernen!")
+                .GetXml();
+
+            var toast = new ScheduledToastNotification(xml, next) { Tag = ToastTag };
+            notifier.AddToSchedule(toast);
+        }
+
+        public static void CancelReminder()
+        {
+            var notifier = ToastNotificationManager.CreateToastNotifier();
+            foreach (var scheduled in notifier.GetScheduledToastNotifications().Where(t => t.Tag == ToastTag).ToList())
+            {
+                notifier.RemoveFromSchedule(scheduled);
+            }
+        }
+    }
+}

--- a/NeoCardium/ViewModels/SettingsPageViewModel.cs
+++ b/NeoCardium/ViewModels/SettingsPageViewModel.cs
@@ -2,6 +2,7 @@ using System;
 using CommunityToolkit.Mvvm.ComponentModel;
 using Microsoft.UI.Xaml;
 using Windows.Storage;
+using NeoCardium.Services;
 
 namespace NeoCardium.ViewModels
 {
@@ -12,6 +13,8 @@ namespace NeoCardium.ViewModels
         private const string ThemeKey = "AppTheme";
         private const string StatsKey = "ShowStatistics";
         private const string LicenseKey = "LicenseStatus";
+        private const string ReminderEnabledKey = "ReminderEnabled";
+        private const string ReminderTimeKey = "ReminderTime";
 
         private string _selectedTheme = "Default";
         public string SelectedTheme
@@ -39,6 +42,44 @@ namespace NeoCardium.ViewModels
                 if (SetProperty(ref _showStatistics, value))
                 {
                     localSettings.Values[StatsKey] = value;
+                }
+            }
+        }
+
+        private bool _reminderEnabled;
+        public bool ReminderEnabled
+        {
+            get => _reminderEnabled;
+            set
+            {
+                if (SetProperty(ref _reminderEnabled, value))
+                {
+                    localSettings.Values[ReminderEnabledKey] = value;
+                    if (value)
+                    {
+                        ReminderService.ScheduleDailyReminder(ReminderTime);
+                    }
+                    else
+                    {
+                        ReminderService.CancelReminder();
+                    }
+                }
+            }
+        }
+
+        private TimeSpan _reminderTime = new(9, 0, 0);
+        public TimeSpan ReminderTime
+        {
+            get => _reminderTime;
+            set
+            {
+                if (SetProperty(ref _reminderTime, value))
+                {
+                    localSettings.Values[ReminderTimeKey] = value.ToString();
+                    if (ReminderEnabled)
+                    {
+                        ReminderService.ScheduleDailyReminder(value);
+                    }
                 }
             }
         }
@@ -71,6 +112,16 @@ namespace NeoCardium.ViewModels
             if (localSettings.Values.TryGetValue(LicenseKey, out var licObj) && licObj is string storedLicense)
             {
                 _licenseStatus = storedLicense;
+            }
+
+            if (localSettings.Values.TryGetValue(ReminderEnabledKey, out var remEnabledObj) && remEnabledObj is bool storedEnabled)
+            {
+                _reminderEnabled = storedEnabled;
+            }
+
+            if (localSettings.Values.TryGetValue(ReminderTimeKey, out var remTimeObj) && remTimeObj is string storedTime && TimeSpan.TryParse(storedTime, out var span))
+            {
+                _reminderTime = span;
             }
         }
     }

--- a/NeoCardium/Views/SettingsPage.xaml
+++ b/NeoCardium/Views/SettingsPage.xaml
@@ -28,6 +28,13 @@
             <TextBlock Text="Allgemein" FontWeight="SemiBold" Margin="0,10,0,5"/>
             <CheckBox Content="Statistik anzeigen" IsChecked="{x:Bind ViewModel.ShowStatistics, Mode=TwoWay}"/>
         </StackPanel>
+
+        <!-- Reminder settings -->
+        <StackPanel>
+            <TextBlock Text="Erinnerung" FontWeight="SemiBold" Margin="0,10,0,5"/>
+            <ToggleSwitch Content="Tägliche Erinnerung" IsOn="{x:Bind ViewModel.ReminderEnabled, Mode=TwoWay}"/>
+            <TimePicker Time="{x:Bind ViewModel.ReminderTime, Mode=TwoWay}" Visibility="{x:Bind ViewModel.ReminderEnabled, Converter={StaticResource BooleanToVisibilityConverter}}"/>
+        </StackPanel>
       
       <!-- Language settings -->
       <StackPanel Orientation="Horizontal" Spacing="10" HorizontalAlignment="Center">


### PR DESCRIPTION
## Summary
- add CommunityToolkit toast notifications package
- create `ReminderService` to schedule or cancel daily toasts
- expose reminder toggle and time picker in settings UI
- persist reminder preferences in `SettingsPageViewModel`
- schedule reminder on app launch if enabled

## Testing
- `dotnet build NeoCardium/NeoCardium.csproj -c Release` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684f51e00510832ead49869c81ce9845