### PR TITLE
Fix outdated toolkit dependencies

### DIFF
--- a/NeoCardium/NeoCardium.csproj
+++ b/NeoCardium/NeoCardium.csproj
@@ -51,11 +51,11 @@
   
   <ItemGroup>
     <PackageReference Include="CommunityToolkit.Mvvm" Version="8.4.0" />
-    <PackageReference Include="CommunityToolkit.WinUI.UI.Controls" Version="8.2.1" />
+    <PackageReference Include="CommunityToolkit.WinUI.UI.Controls" Version="8.2.2" />
     <PackageReference Include="Microsoft.Data.Sqlite" Version="9.0.2" />
     <PackageReference Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.26100.1742" />
     <PackageReference Include="Microsoft.WindowsAppSDK" Version="1.6.250205002" />
-    <PackageReference Include="CommunityToolkit.WinUI.Notifications" Version="8.1.0" />
+    <PackageReference Include="CommunityToolkit.WinUI.Notifications" Version="8.2.2" />
   </ItemGroup>
   
   <ItemGroup>


### PR DESCRIPTION
## Summary
- bump `CommunityToolkit.WinUI.UI.Controls` to 8.2.2
- bump `CommunityToolkit.WinUI.Notifications` to 8.2.2

## Testing
- `dotnet --version` *(fails: command not found)*
- `ping -c 1 nuget.org` *(fails: network unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_684fd349c47c832eb1ef6c50c6257478