### PR TITLE
Remove x:DataType from pages

### DIFF
--- a/NeoCardium/Views/SettingsPage.xaml
+++ b/NeoCardium/Views/SettingsPage.xaml
@@ -7,7 +7,6 @@
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     mc:Ignorable="d"
     xmlns:vm="using:NeoCardium.ViewModels"
-    x:DataType="vm:SettingsPageViewModel"
     Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
 
     <StackPanel Padding="20" Spacing="20">

--- a/NeoCardium/Views/StatsPage.xaml
+++ b/NeoCardium/Views/StatsPage.xaml
@@ -7,14 +7,13 @@
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:charting="using:CommunityToolkit.WinUI.UI.Controls"
     mc:Ignorable="d"
-    xmlns:vm="using:NeoCardium.ViewModels"
-    x:DataType="vm:StatsPageViewModel">
+    xmlns:vm="using:NeoCardium.ViewModels">
 
     <StackPanel Padding="20" Spacing="20">
         <TextBlock Text="Learning History" FontSize="24" FontWeight="Bold"/>
-        <charting:Chart x:Name="HistoryChart" Height="300" ItemsSource="{x:Bind DailyStats}">
-            <charting:LineSeries ItemsSource="{x:Bind DailyStats}" IndependentValuePath="Date" DependentValuePath="Correct" Title="Correct"/>
-            <charting:LineSeries ItemsSource="{x:Bind DailyStats}" IndependentValuePath="Date" DependentValuePath="Incorrect" Title="Incorrect"/>
+        <charting:Chart x:Name="HistoryChart" Height="300" ItemsSource="{x:Bind ViewModel.DailyStats}">
+            <charting:LineSeries ItemsSource="{x:Bind ViewModel.DailyStats}" IndependentValuePath="Date" DependentValuePath="Correct" Title="Correct"/>
+            <charting:LineSeries ItemsSource="{x:Bind ViewModel.DailyStats}" IndependentValuePath="Date" DependentValuePath="Incorrect" Title="Incorrect"/>
         </charting:Chart>
         <StackPanel Orientation="Horizontal" HorizontalAlignment="Center" Spacing="10">
             <Button Content="Reset" Command="{x:Bind ViewModel.ResetStatsCommand}"/>

--- a/NeoCardium/Views/StatsPage.xaml.cs
+++ b/NeoCardium/Views/StatsPage.xaml.cs
@@ -1,12 +1,16 @@
 using Microsoft.UI.Xaml.Controls;
+using NeoCardium.ViewModels;
 
 namespace NeoCardium.Views
 {
     public sealed partial class StatsPage : Page
     {
+        public StatsPageViewModel ViewModel { get; } = new StatsPageViewModel();
+
         public StatsPage()
         {
             this.InitializeComponent();
+            DataContext = ViewModel;
         }
     }
 }


### PR DESCRIPTION
## Summary
- remove x:DataType from `SettingsPage.xaml`
- remove x:DataType from `StatsPage.xaml` and move bindings to use a `ViewModel` property
- initialize `ViewModel` and set `DataContext` in `StatsPage.xaml.cs`

## Testing
- `dotnet build NeoCardium.sln -c Debug` *(fails: dotnet not found)*

------
https://chatgpt.com/codex/tasks/task_e_684fd340acc4832e9391cd82e61401cb